### PR TITLE
Formatted composer.json using JQ --indent 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
-  "name": "ibexa/i18n",
-  "description": "Ibexa translations",
-  "license": "(GPL-2.0-only or proprietary)",
-  "require": {
-    "ibexa/core": "~4.5.0@dev"
-  },
-  "require-dev": {},
-  "extra": {
-    "branch-alias": {
-      "dev-main": "4.5.x-dev"
+    "name": "ibexa/i18n",
+    "description": "Ibexa translations",
+    "license": "(GPL-2.0-only or proprietary)",
+    "require": {
+        "ibexa/core": "~4.5.0@dev"
+    },
+    "require-dev": {},
+    "extra": {
+        "branch-alias": {
+            "dev-main": "4.5.x-dev"
+        }
     }
-  }
 }


### PR DESCRIPTION
| Question                       | Answer                                                |
|--------------------------------|-------------------------------------------------------|
| **JIRA issue**                 | n/a |
| **Type**                       | improvement                               |
| **Target Ibexa version** | `v4.5`+                |
| **BC breaks**                  | no                                                |

Aligned indent of `composer.json` to 4 spaces, for consistency's sake with the pre-existing conventions, ease of merge-ups and task automation.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.