### PR TITLE
IBX-9648: Added missing translations for default richtext btns

### DIFF
--- a/fieldtype-richtext/ck_editor.xlf
+++ b/fieldtype-richtext/ck_editor.xlf
@@ -36,6 +36,136 @@
         <target state="new">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="new">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="new">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="new">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="new">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="new">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="new">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="new">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="new">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="new">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="new">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="new">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="new">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="new">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="new">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="new">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="new">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="new">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="new">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="new">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="new">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="new">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="new">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="new">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="new">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="new">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="new">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="new">Custom attributes</target>

--- a/translations/ach_UG/fieldtype-richtext/ck_editor.ach-UG.xlf
+++ b/translations/ach_UG/fieldtype-richtext/ck_editor.ach-UG.xlf
@@ -36,6 +36,136 @@
         <target>crwdns247114:0crwdne247114:0</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target>crwdns245132:0crwdne245132:0</target>

--- a/translations/de_DE/fieldtype-richtext/ck_editor.de.xlf
+++ b/translations/de_DE/fieldtype-richtext/ck_editor.de.xlf
@@ -36,6 +36,136 @@
         <target state="translated">Rechts</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="translated">Benutzerdefinierte Attribute</target>

--- a/translations/el_GR/fieldtype-richtext/ck_editor.el.xlf
+++ b/translations/el_GR/fieldtype-richtext/ck_editor.el.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/en_US/fieldtype-richtext/ck_editor.en_US.xlf
+++ b/translations/en_US/fieldtype-richtext/ck_editor.en_US.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/es_ES/fieldtype-richtext/ck_editor.es.xlf
+++ b/translations/es_ES/fieldtype-richtext/ck_editor.es.xlf
@@ -36,6 +36,136 @@
         <target state="translated">Derecha</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="translated">Atributos personalizados</target>

--- a/translations/fr_FR/fieldtype-richtext/ck_editor.fr.xlf
+++ b/translations/fr_FR/fieldtype-richtext/ck_editor.fr.xlf
@@ -36,6 +36,136 @@
         <target state="translated">Droite</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="translated">Attributs personnalisés</target>

--- a/translations/hr_HR/fieldtype-richtext/ck_editor.hr.xlf
+++ b/translations/hr_HR/fieldtype-richtext/ck_editor.hr.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/hu_HU/fieldtype-richtext/ck_editor.hu.xlf
+++ b/translations/hu_HU/fieldtype-richtext/ck_editor.hu.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/it_IT/fieldtype-richtext/ck_editor.it.xlf
+++ b/translations/it_IT/fieldtype-richtext/ck_editor.it.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/ja_JP/fieldtype-richtext/ck_editor.ja.xlf
+++ b/translations/ja_JP/fieldtype-richtext/ck_editor.ja.xlf
@@ -36,6 +36,136 @@
         <target state="translated">右寄せ</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="translated">カスタム属性</target>

--- a/translations/nb_NO/fieldtype-richtext/ck_editor.nb.xlf
+++ b/translations/nb_NO/fieldtype-richtext/ck_editor.nb.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/pl_PL/fieldtype-richtext/ck_editor.pl.xlf
+++ b/translations/pl_PL/fieldtype-richtext/ck_editor.pl.xlf
@@ -36,6 +36,136 @@
         <target state="translated">Do prawej</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="translated">Własne atrybuty</target>

--- a/translations/pt_PT/fieldtype-richtext/ck_editor.pt.xlf
+++ b/translations/pt_PT/fieldtype-richtext/ck_editor.pt.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/ru_RU/fieldtype-richtext/ck_editor.ru.xlf
+++ b/translations/ru_RU/fieldtype-richtext/ck_editor.ru.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>

--- a/translations/zh_HK/fieldtype-richtext/ck_editor.zh_HK.xlf
+++ b/translations/zh_HK/fieldtype-richtext/ck_editor.zh_HK.xlf
@@ -36,6 +36,136 @@
         <target state="needs-translation">Right</target>
         <note>key: block_alignment.right</note>
       </trans-unit>
+      <trans-unit id="666d0e93c1d10379c28667c6b8a5205de69e6ed0" resname="text_align_left_btn.label">
+        <source>Align left</source>
+        <target state="needs-translation">Align left</target>
+        <note>key: text_align_left_btn.label</note>
+      </trans-unit>
+      <trans-unit id="d90b6ee677c7203a977cb0e649cb74d797e7ea9a" resname="text_align_right_btn.label">
+        <source>Align right</source>
+        <target state="needs-translation">Align right</target>
+        <note>key: text_align_right_btn.label</note>
+      </trans-unit>
+      <trans-unit id="63524491e6970e55a799ac316cde8af0a28106ed" resname="text_align_center_btn.label">
+        <source>Align center</source>
+        <target state="needs-translation">Align center</target>
+        <note>key: text_align_center_btn.label</note>
+      </trans-unit>
+      <trans-unit id="03d040bc1240e465fd590f329324006005600a6e" resname="text_align_justify_btn.label">
+        <source>Justify</source>
+        <target state="needs-translation">Justify</target>
+        <note>key: text_align_justify_btn.label</note>
+      </trans-unit>
+      <trans-unit id="729dcbfb5087014ee166508147ea21d639bc8be1" resname="bulleted_list_disc_btn.label">
+        <source>Disc</source>
+        <target state="needs-translation">Disc</target>
+        <note>key: bulleted_list_disc_btn.label</note>
+      </trans-unit>
+      <trans-unit id="66d4db738ddd23ae5eb9dd4b174ce66999f0a98c" resname="bulleted_list_circle_btn.label">
+        <source>Circle</source>
+        <target state="needs-translation">Circle</target>
+        <note>key: bulleted_list_circle_btn.label</note>
+      </trans-unit>
+      <trans-unit id="be6c6a090eec768bb0834f5ac136750ff54336b8" resname="bulleted_list_square_btn.label">
+        <source>Square</source>
+        <target state="needs-translation">Square</target>
+        <note>key: bulleted_list_square_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e5ff83a559e038d982d19b736845c6ea019f5b26" resname="numbered_list_decimal_btn.label">
+        <source>Decimal</source>
+        <target state="needs-translation">Decimal</target>
+        <note>key: numbered_list_decimal_btn.label</note>
+      </trans-unit>
+      <trans-unit id="e24538dfd2ecdad33c911356de12964d90794fad" resname="numbered_list_decimal_leading_zero_btn.label">
+        <source>Decimal with leading zero</source>
+        <target state="needs-translation">Decimal with leading zero</target>
+        <note>key: numbered_list_decimal_leading_zero_btn.label</note>
+      </trans-unit>
+      <trans-unit id="5b3d3af5361fa0e2c0deeb0b3375f6b8984743d9" resname="numbered_list_lower_roman_btn.label">
+        <source>Lower-roman</source>
+        <target state="needs-translation">Lower-roman</target>
+        <note>key: numbered_list_lower_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="19afeb77e96f65cfd03554011ecb7a43483322a4" resname="numbered_list_upper_roman_btn.label">
+        <source>Upper-roman</source>
+        <target state="needs-translation">Upper-roman</target>
+        <note>key: numbered_list_upper_roman_btn.label</note>
+      </trans-unit>
+      <trans-unit id="6827cbc6196cb624ace6cfca7448c19dcd658cf6" resname="numbered_list_lower_latin_btn.label">
+        <source>Lower-latin</source>
+        <target state="needs-translation">Lower-latin</target>
+        <note>key: numbered_list_lower_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="9b11a66d415cf50c0c8f4230664202aaadac8c78" resname="numbered_list_upper_latin_btn.label">
+        <source>Upper-latin</source>
+        <target state="needs-translation">Upper-latin</target>
+        <note>key: numbered_list_upper_latin_btn.label</note>
+      </trans-unit>
+      <trans-unit id="841a18570b88796e700e0d0cd2f8d4e99f9e13bd" resname="heading_btn.label">
+        <source>Heading</source>
+        <target state="needs-translation">Heading</target>
+        <note>key: heading_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1239bd7ca8264ebe43c8ea4b8a0f65f6a8f2a871" resname="subscript_btn.label">
+        <source>Subscript</source>
+        <target state="needs-translation">Subscript</target>
+        <note>key: subscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="c411f5e01621d10502208ca786037ccb015662f6" resname="superscript_btn.label">
+        <source>Superscript</source>
+        <target state="needs-translation">Superscript</target>
+        <note>key: superscript_btn.label</note>
+      </trans-unit>
+      <trans-unit id="928a20984283fd0c72b7928f96f203f4d3681e07" resname="strikethrough_btn.label">
+        <source>Strikethrough</source>
+        <target state="needs-translation">Strikethrough</target>
+        <note>key: strikethrough_btn.label</note>
+      </trans-unit>
+      <trans-unit id="70ca87fcf27a898c58f2e73258650c67ff3e1f56" resname="block_quote_btn.label">
+        <source>Block quote</source>
+        <target state="needs-translation">Block quote</target>
+        <note>key: block_quote_btn.label</note>
+      </trans-unit>
+      <trans-unit id="994c86efdcdc4e5db5aab3b391051eab3b82ccc9" resname="special_characters_btn.label">
+        <source>Special characters</source>
+        <target state="needs-translation">Special characters</target>
+        <note>key: special_characters_btn.label</note>
+      </trans-unit>
+      <trans-unit id="8a7b727028f9b9ffe3673a8925e7876e0378d7cf" resname="bold_btn.label">
+        <source>Bold</source>
+        <target state="needs-translation">Bold</target>
+        <note>key: bold_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b8d37b77d1c5025aafb01e31c800e6d44add76ca" resname="italic_btn.label">
+        <source>Italic</source>
+        <target state="needs-translation">Italic</target>
+        <note>key: italic_btn.label</note>
+      </trans-unit>
+      <trans-unit id="68e9c9bf0ce91623f9ccc573e31c47d241f9e440" resname="underline_btn.label">
+        <source>Underline</source>
+        <target state="needs-translation">Underline</target>
+        <note>key: underline_btn.label</note>
+      </trans-unit>
+      <trans-unit id="29479094bf3a1369d96b25f22f5a04f31e1fbd59" resname="bulleted_list_btn.label">
+        <source>Bulleted List</source>
+        <target state="needs-translation">Bulleted List</target>
+        <note>key: bulleted_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="336cf6c262d3ceee7d0d0636a03325e2f666b69c" resname="numbered_list_btn.label">
+        <source>Numbered List</source>
+        <target state="needs-translation">Numbered List</target>
+        <note>key: numbered_list_btn.label</note>
+      </trans-unit>
+      <trans-unit id="a83d599d0f6baf964e4fad7384f781f00fd6f9fc" resname="insert_table_btn.label">
+        <source>Insert table</source>
+        <target state="needs-translation">Insert table</target>
+        <note>key: insert_table_btn.label</note>
+      </trans-unit>
+      <trans-unit id="1653f5eca5bc3d16922be6090d0e87e086110c4a" resname="text_alignment_btn.label">
+        <source>Text alignment</source>
+        <target state="needs-translation">Text alignment</target>
+        <note>key: text_alignment_btn.label</note>
+      </trans-unit>
       <trans-unit id="250e037cfe2d6e349e2da22428ac75e7559f1d66" resname="custom_attributes_btn.label">
         <source>Custom attributes</source>
         <target state="needs-translation">Custom attributes</target>


### PR DESCRIPTION
| :ticket: Issue | IBX-9648 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/fieldtype-richtext/pull/295

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
