### PR TITLE
IBX-9648: Added missing translations for custom richtext btns

### DIFF
--- a/translations/de_DE/fieldtype-richtext/ck_editor.de.xlf
+++ b/translations/de_DE/fieldtype-richtext/ck_editor.de.xlf
@@ -21,6 +21,21 @@
         <target state="translated">Anker</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="translated">Mitte</target>
@@ -41,6 +56,21 @@
         <target state="translated">Benutzerdefinierte Attribute</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="translated">Benutzerdefinierte Stile</target>
@@ -50,6 +80,16 @@
         <source>Settings</source>
         <target state="translated">Einstellungen</target>
         <note>key: custom_tag.settings.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
       </trans-unit>
       <trans-unit id="af69b1457df848a63cb4c9cb2acf4583f110fb84" resname="custom_tag.toolbar.label">
         <source>Custom tag toolbar</source>
@@ -105,6 +145,46 @@
         <source>Link</source>
         <target state="translated">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/el_GR/fieldtype-richtext/ck_editor.el.xlf
+++ b/translations/el_GR/fieldtype-richtext/ck_editor.el.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/en_US/fieldtype-richtext/ck_editor.en_US.xlf
+++ b/translations/en_US/fieldtype-richtext/ck_editor.en_US.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/es_ES/fieldtype-richtext/ck_editor.es.xlf
+++ b/translations/es_ES/fieldtype-richtext/ck_editor.es.xlf
@@ -21,6 +21,21 @@
         <target state="translated">Anclaje</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="translated">Centro</target>
@@ -41,6 +56,21 @@
         <target state="translated">Atributos personalizados</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="translated">Estilos personalizados</target>
@@ -50,6 +80,16 @@
         <source>Settings</source>
         <target state="translated">Configuración</target>
         <note>key: custom_tag.settings.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="af69b1457df848a63cb4c9cb2acf4583f110fb84" resname="custom_tag.toolbar.label">
         <source>Custom tag toolbar</source>
@@ -105,6 +145,46 @@
         <source>Link</source>
         <target state="translated">Enlace</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/fr_FR/fieldtype-richtext/ck_editor.fr.xlf
+++ b/translations/fr_FR/fieldtype-richtext/ck_editor.fr.xlf
@@ -21,6 +21,21 @@
         <target state="translated">Ancre</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="translated">Centrer</target>
@@ -41,6 +56,21 @@
         <target state="translated">Attributs personnalisés</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="translated">Styles personnalisés</target>
@@ -50,6 +80,16 @@
         <source>Settings</source>
         <target state="translated">Paramètres</target>
         <note>key: custom_tag.settings.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="af69b1457df848a63cb4c9cb2acf4583f110fb84" resname="custom_tag.toolbar.label">
         <source>Custom tag toolbar</source>
@@ -105,6 +145,46 @@
         <source>Link</source>
         <target state="translated">Lien</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/hr_HR/fieldtype-richtext/ck_editor.hr.xlf
+++ b/translations/hr_HR/fieldtype-richtext/ck_editor.hr.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/hu_HU/fieldtype-richtext/ck_editor.hu.xlf
+++ b/translations/hu_HU/fieldtype-richtext/ck_editor.hu.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/it_IT/fieldtype-richtext/ck_editor.it.xlf
+++ b/translations/it_IT/fieldtype-richtext/ck_editor.it.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/ja_JP/fieldtype-richtext/ck_editor.ja.xlf
+++ b/translations/ja_JP/fieldtype-richtext/ck_editor.ja.xlf
@@ -21,6 +21,21 @@
         <target state="translated">アンカー</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="translated">中央寄せ</target>
@@ -41,10 +56,35 @@
         <target state="translated">カスタム属性</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="translated">カスタムスタイル</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="translated">リンク</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/nb_NO/fieldtype-richtext/ck_editor.nb.xlf
+++ b/translations/nb_NO/fieldtype-richtext/ck_editor.nb.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/pl_PL/fieldtype-richtext/ck_editor.pl.xlf
+++ b/translations/pl_PL/fieldtype-richtext/ck_editor.pl.xlf
@@ -21,6 +21,21 @@
         <target state="translated">Kotwica</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="translated">Wyśrodkuj</target>
@@ -41,10 +56,35 @@
         <target state="translated">Własne atrybuty</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="translated">Własny styl</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -58,7 +98,7 @@
       </trans-unit>
       <trans-unit id="b4f97f21f1ca738b786232732212d980e2509dfa" resname="embed_inline_btn.label">
         <source>Embed inline</source>
-        <target state="translated">Osadzo inline</target>
+        <target state="translated">Osadź inline</target>
         <note>key: embed_inline_btn.label</note>
       </trans-unit>
       <trans-unit id="60187109a21e0437d6b91e9762fd1c69a79062be" resname="formatted_btn.label">
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="translated">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/pt_PT/fieldtype-richtext/ck_editor.pt.xlf
+++ b/translations/pt_PT/fieldtype-richtext/ck_editor.pt.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/ru_RU/fieldtype-richtext/ck_editor.ru.xlf
+++ b/translations/ru_RU/fieldtype-richtext/ck_editor.ru.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>

--- a/translations/zh_HK/fieldtype-richtext/ck_editor.zh_HK.xlf
+++ b/translations/zh_HK/fieldtype-richtext/ck_editor.zh_HK.xlf
@@ -21,6 +21,21 @@
         <target state="needs-translation">Anchor</target>
         <note>key: anchor_btn.label</note>
       </trans-unit>
+      <trans-unit id="4ab23dd2b761a9f1db3704416bed038dc06f1625" resname="anchor_btn.input.name">
+        <source>Name</source>
+        <target state="needs-translation">Name</target>
+        <note>key: anchor_btn.input.name</note>
+      </trans-unit>
+      <trans-unit id="db29c4c0eedb9f53fc1e570a20cddb4c391dd290" resname="anchor_btn.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: anchor_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="e04cfecaf1fb746f1077e13be1ef8c163d0d5ec5" resname="anchor_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: anchor_btn.save.label</note>
+      </trans-unit>
       <trans-unit id="18521c98ecdb47eba2ceee2926516d53f89b0e34" resname="block_alignment.center">
         <source>Center</source>
         <target state="needs-translation">Center</target>
@@ -41,10 +56,35 @@
         <target state="needs-translation">Custom attributes</target>
         <note>key: custom_attributes_btn.label</note>
       </trans-unit>
+      <trans-unit id="1f8a183a4d1d4d74a5ce13f45a008bac73c2b878" resname="custom_attributes.remove.label">
+        <source>Remove</source>
+        <target state="needs-translation">Remove</target>
+        <note>key: custom_attributes.remove.label</note>
+      </trans-unit>
+      <trans-unit id="39cd8d778cc5462b7ab99f304fcf7f906e988b2f" resname="custom_attributes.revert.label">
+        <source>Revert to saved</source>
+        <target state="needs-translation">Revert to saved</target>
+        <note>key: custom_attributes.revert.label</note>
+      </trans-unit>
+      <trans-unit id="dc8843e639e3ecba7dca9905a701d12eafc44c54" resname="custom_attributes.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_attributes.save.label</note>
+      </trans-unit>
       <trans-unit id="fb7fb71848f42499261b9e92b40f0254e730ddd4" resname="custom_styles_btn.label">
         <source>Custom styles</source>
         <target state="needs-translation">Custom styles</target>
         <note>key: custom_styles_btn.label</note>
+      </trans-unit>
+      <trans-unit id="b3206e346182e25a8b3d0ff8ab6d34fbcc713eca" resname="custom_tag.cancel.label">
+        <source>Cancel</source>
+        <target state="needs-translation">Cancel</target>
+        <note>key: custom_tag.cancel.label</note>
+      </trans-unit>
+      <trans-unit id="4642c8bf0fe5579726d5ce6a28a6ecfeef5f2737" resname="custom_tag.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: custom_tag.save.label</note>
       </trans-unit>
       <trans-unit id="3b257be2c6dd1f7bf0d5c70e64c22bf5b298dbbf" resname="elements_path.list.label">
         <source>list</source>
@@ -75,6 +115,46 @@
         <source>Link</source>
         <target state="needs-translation">Link</target>
         <note>key: link_btn.label</note>
+      </trans-unit>
+      <trans-unit id="79f4ef7374ddae6ec8a697de5aaf84ab29786aac" resname="link_btn.input.title">
+        <source>Title</source>
+        <target state="needs-translation">Title</target>
+        <note>key: link_btn.input.title</note>
+      </trans-unit>
+      <trans-unit id="9675a032fdb0a24b98a2f10392454eed40c2f5cc" resname="link_btn.input.url">
+        <source>Link to</source>
+        <target state="needs-translation">Link to</target>
+        <note>key: link_btn.input.url</note>
+      </trans-unit>
+      <trans-unit id="08499e240f53a85b0903a671566701d6c14bd5e0" resname="link_btn.open_in_tab.label">
+        <source>Open in tab</source>
+        <target state="needs-translation">Open in tab</target>
+        <note>key: link_btn.open_in_tab.label</note>
+      </trans-unit>
+      <trans-unit id="1a0be56348c06f3f4f515404114790b94d69cafd" resname="link_btn.remove_attributes.label">
+        <source>Remove attributes</source>
+        <target state="needs-translation">Remove attributes</target>
+        <note>key: link_btn.remove_attributes.label</note>
+      </trans-unit>
+      <trans-unit id="e2ee962de7749dd4262f9bf397d7821c5bee4316" resname="link_btn.remove.label">
+        <source>Remove link</source>
+        <target state="needs-translation">Remove link</target>
+        <note>key: link_btn.remove.label</note>
+      </trans-unit>
+      <trans-unit id="fef99c8cc2308146608471cfe13ac4f51a69f9da" resname="link_btn.save.label">
+        <source>Save</source>
+        <target state="needs-translation">Save</target>
+        <note>key: link_btn.save.label</note>
+      </trans-unit>
+      <trans-unit id="117e540a4598f927fba295fd7db1c3c1677628bb" resname="link_btn.select_content.label">
+        <source>Select content</source>
+        <target state="needs-translation">Select content</target>
+        <note>key: link_btn.select_content.label</note>
+      </trans-unit>
+      <trans-unit id="28c9515009db451ab8e1affb40edaeb51a24042b" resname="link_btn.site_access.label">
+        <source>Site access</source>
+        <target state="needs-translation">Site access</target>
+        <note>key: link_btn.site_access.label</note>
       </trans-unit>
       <trans-unit id="082d2d34dd20fe267d5693d3f6a2c8be105c490c" resname="move_down_btn.title">
         <source>Move down</source>


### PR DESCRIPTION
| :ticket: Issue | IBX-9648 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/fieldtype-richtext/pull/295

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
